### PR TITLE
refactor: StartAsync and IdentifyAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ var anonymousUser = FbUser.Builder("anonymous")
 
 // Creates a new client instance that connects to FeatBit with the custom option.
 var client = new FbClient(options, anonymousUser);
-if (!client.Initialized)
+
+// Starts the client and wait up to 3 seconds for the client to be ready.
+var success = await client.StartAsync(TimeSpan.FromSeconds(3));
+if (!success)
 {
     Console.WriteLine("FbClient failed to initialize. All Variation calls will use fallback value.");
 }

--- a/src/FeatBit.ClientSdk/Concurrent/TaskExtensions.cs
+++ b/src/FeatBit.ClientSdk/Concurrent/TaskExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FeatBit.Sdk.Client.Concurrent
+{
+    public static class TaskExtensions
+    {
+        public static async Task<T> WithTimeout<T>(this Task<T> task, TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource();
+            var delayTask = Task.Delay(timeout, cts.Token);
+
+            var resultTask = await Task.WhenAny(task, delayTask);
+            if (resultTask == delayTask)
+            {
+                // Operation cancelled
+                throw new OperationCanceledException();
+            }
+
+            // Cancel the timer task so that it does not fire
+            cts.Cancel();
+
+            return await task;
+        }
+    }
+}

--- a/src/FeatBit.ClientSdk/DataSynchronizer/PollingDataSynchronizer.cs
+++ b/src/FeatBit.ClientSdk/DataSynchronizer/PollingDataSynchronizer.cs
@@ -125,7 +125,7 @@ namespace FeatBit.Sdk.Client.DataSynchronizer
         public void Dispose()
         {
             _canceller?.Cancel();
-            _canceller = null;
+            _canceller?.Dispose();
 
             _getUserFlags?.Dispose();
         }

--- a/src/FeatBit.ClientSdk/IFbClient.cs
+++ b/src/FeatBit.ClientSdk/IFbClient.cs
@@ -21,9 +21,19 @@ namespace FeatBit.Sdk.Client
         IFlagTracker FlagTracker { get; }
 
         /// <summary>
+        /// Starts FbClient
+        /// </summary>
+        /// <param name="startTimeout">the maximum time to wait for the client to start, defaults to 3 seconds if not provided</param>
+        /// <returns>true if the client is successfully started within the timeout</returns>
+        Task<bool> StartAsync(TimeSpan? startTimeout = null);
+
+        /// <summary>
         /// Changes the current evaluation user and requests flags for that user.
         /// </summary>
-        Task IdentifyAsync(FbUser user);
+        /// <param name="user">the new user</param>
+        /// <param name="identifyTimeout">the maximum time to wait for the user to be identified, defaults to 3 seconds if not provided</param>
+        /// <returns>true if the user is successfully identified within the timeout</returns>
+        Task<bool> IdentifyAsync(FbUser user, TimeSpan? identifyTimeout = null);
 
         /// <summary>
         /// Get the boolean value of a feature flag for current user.

--- a/src/FeatBit.ClientSdk/IFbClient.cs
+++ b/src/FeatBit.ClientSdk/IFbClient.cs
@@ -21,7 +21,7 @@ namespace FeatBit.Sdk.Client
         IFlagTracker FlagTracker { get; }
 
         /// <summary>
-        /// Starts FbClient
+        /// Starts FbClient and waits for the client to be ready.
         /// </summary>
         /// <param name="startTimeout">the maximum time to wait for the client to start, defaults to 3 seconds if not provided</param>
         /// <returns>true if the client is successfully started within the timeout</returns>

--- a/src/FeatBit.ClientSdk/Options/FbOptions.cs
+++ b/src/FeatBit.ClientSdk/Options/FbOptions.cs
@@ -8,12 +8,6 @@ namespace FeatBit.Sdk.Client.Options
     public sealed class FbOptions
     {
         /// <summary>
-        /// How long the client constructor will block awaiting a successful connection to FeatBit.
-        /// </summary>
-        /// <value>Defaults to 5 seconds</value>
-        public TimeSpan StartWaitTime { get; set; }
-
-        /// <summary>
         /// Whether or not this client is offline. If true, no calls to FeatBit will be made.
         /// </summary>
         /// <value>Defaults to <c>false</c></value>
@@ -61,7 +55,6 @@ namespace FeatBit.Sdk.Client.Options
         public ILoggerFactory LoggerFactory { get; set; }
 
         internal FbOptions(
-            TimeSpan startWaitTime,
             bool offline,
             FeatureFlag[] bootstrap,
             string secret,
@@ -71,7 +64,6 @@ namespace FeatBit.Sdk.Client.Options
             Uri eventUri,
             ILoggerFactory loggerFactory)
         {
-            StartWaitTime = startWaitTime;
             Offline = offline;
             Bootstrap = bootstrap;
             Secret = secret;

--- a/src/FeatBit.ClientSdk/Options/FbOptionsBuilder.cs
+++ b/src/FeatBit.ClientSdk/Options/FbOptionsBuilder.cs
@@ -7,8 +7,6 @@ namespace FeatBit.Sdk.Client.Options
 {
     public class FbOptionsBuilder
     {
-        private TimeSpan _startWaitTime;
-
         private readonly string _secret;
         private bool _offline;
         private FeatureFlag[] _bootstrap;
@@ -24,8 +22,6 @@ namespace FeatBit.Sdk.Client.Options
 
         public FbOptionsBuilder(string secret)
         {
-            _startWaitTime = TimeSpan.FromSeconds(5);
-
             _offline = false;
             _bootstrap = Array.Empty<FeatureFlag>();
             _secret = secret;
@@ -41,14 +37,8 @@ namespace FeatBit.Sdk.Client.Options
 
         public FbOptions Build()
         {
-            return new FbOptions(_startWaitTime, _offline, _bootstrap, _secret, _dataSyncMode, _pollingUri,
-                _pollingInterval, _eventUri, _loggerFactory);
-        }
-
-        public FbOptionsBuilder StartWaitTime(TimeSpan startWaitTime)
-        {
-            _startWaitTime = startWaitTime;
-            return this;
+            return new FbOptions(_offline, _bootstrap, _secret, _dataSyncMode, _pollingUri, _pollingInterval, _eventUri,
+                _loggerFactory);
         }
 
         public FbOptionsBuilder Polling(Uri pollingUri, TimeSpan? pollingInterval = null)


### PR DESCRIPTION
- Let users to start `FbClient` explicitly with a timeout
- Add timeout to `IdentifyAsync` method
- Fixed a bug in `PollingDataSynchronizer` (shouldn't set the `_canceller` to null)